### PR TITLE
bug(DCP-1581): Bump drf from v3.14.0 to v3.16.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Django==4.2.20
-djangorestframework==3.14.0
+djangorestframework==3.16.0
 mongoengine
 blinker==1.7.0


### PR DESCRIPTION
Bumps the version of djangorestframework from v3.14.0 to v3.16.0 in
order to fix the vulnerability flagged here:
https://app.snyk.io/org/stream-QoKwzbbYgxQrFD2XJ6mkew/project/c0e9974a-85ab-49fa-80ae-921420b6bc7f#issue-SNYK-PYTHON-DJANGORESTFRAMEWORK-7252137
