### PR TITLE
PAY-4214/Fix-Django-Vulnerability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==5.2.8
+Django==5.2.9
 djangorestframework==3.16.1
 mongoengine
 blinker==1.9.0


### PR DESCRIPTION
This to upgrade the django package from 5.2.8 to 5.2.9